### PR TITLE
Allow empty scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
 # Mosquitto Go Auth Plugin for OAuth2
 
-This is a custom backend for the [mosquitto go auth plugin](https://github.com/iegomez/mosquitto-go-auth) that can handle the authentification and authorization with a oauth2 server.
+This is a custom backend for the [mosquitto go auth plugin](https://github.com/iegomez/mosquitto-go-auth) that can handle the authentication and authorization with a oauth2 server.
 
 ## How to use
 
-This plugin use oauth to authenticate and authorize users for a mqtt broker. Unfornatly is it necassary, that the oauth server response with allowed topics for the user. So the authentication is simple and possible with all kinds of oauth servers. But for the acl check, server have to answer with a special json on the userinfo endpoint. This is the structur: 
+This plugin use oauth to authenticate and authorize users for a mqtt broker. Unfortunately is it necessary, that the oauth server response with allowed topics for the user. So the authentication is simple and possible with all kinds of oauth servers. But for the acl check, server have to answer with a special json on the userinfo endpoint. This is the structur: 
 
 ```json
 {
     "mqtt": {
         "topics": {
             "read": ["sensor/+/rx"],
-            "write": ["application/#", "server_log/mqtt_broker/tx"],
+            "write": ["application/#", "server_log/mqtt_broker/tx"]
         },
-        "superuser": false,
-    },
+        "superuser": false
+    }
 }
 
 ```
 
 We use Keycloak and there you can customize your userinfo.
+
+Configuration options are listed below:
+
+| Options              | Description                                                                                         | Mandatory |
+|----------------------|-----------------------------------------------------------------------------------------------------|:---------:|
+| oauth_client_id      | Oauth2 Client id.                                                                                   |     Y     |
+| oauth_client_secret  | Oauth2 Client secret.                                                                               |     Y     |
+| oauth_token_url      | `token` endpoint url of the Oauth2 server.                                                          |     Y     |
+| oauth_userinfo_url   | `userinfo` endpoint url of the Oauth2 server.                                                       |     Y     |
+| oauth_cache_duration | Cache duration (in seconds) before the plugin request user info from Oauth2 server. `0` by default. |     N     |
+| oauth_scopes         | Comma separated list of requested scopes. No scope by default.                                      |     N     |
 
 ## How to test
 

--- a/example_conf/conf.d/go-auth.conf
+++ b/example_conf/conf.d/go-auth.conf
@@ -2,11 +2,11 @@ auth_plugin /mosquitto/go-auth.so
 
 auth_opt_log_level debug
 auth_opt_log_dest stdout
-auth_opt_backends plugin
+auth_opt_backends plugin, files
 auth_opt_check_prefix false
 
-auth_opt_password_path /etc/mosquitto/auth/passwords
-auth_opt_acl_path /etc/mosquitto/auth/acls
+auth_opt_files_password_path /etc/mosquitto/auth/passwords
+auth_opt_files_acl_path /etc/mosquitto/auth/acls
 
 auth_opt_cache_host redis
 auth_opt_cache false

--- a/src/main.go
+++ b/src/main.go
@@ -213,19 +213,27 @@ func Init(authOpts map[string]string, logLevel log.Level) error {
 	if ok {
 		scopesSplitted = strings.Split(strings.Replace(scopes, " ", "", -1), ",")
 
-	} else {
-		scopesSplitted = []string{"all"}
-	}
+		config = oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			RedirectURL:  "",
+			Scopes:       scopesSplitted,
+			Endpoint: oauth2.Endpoint{
+				TokenURL: tokenURL,
+				AuthURL:  "",
+			},
+		}
 
-	config = oauth2.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		Scopes:       scopesSplitted,
-		RedirectURL:  "",
-		Endpoint: oauth2.Endpoint{
-			TokenURL: tokenURL,
-			AuthURL:  "",
-		},
+	} else {
+		config = oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			RedirectURL:  "",
+			Endpoint: oauth2.Endpoint{
+				TokenURL: tokenURL,
+				AuthURL:  "",
+			},
+		}
 	}
 
 	userCache = make(map[string]userState)

--- a/src/main.go
+++ b/src/main.go
@@ -48,7 +48,7 @@ var userInfoURL string
 var userCache map[string]userState
 var cacheDuration time.Duration
 var version string
-var scopesSplitted []string
+var scopeSplit []string
 
 func getUserInfo(client *http.Client) (*UserInfo, error) {
 	info := UserInfo{}
@@ -211,29 +211,20 @@ func Init(authOpts map[string]string, logLevel log.Level) error {
 	}
 	scopes, ok := authOpts["oauth_scopes"]
 	if ok {
-		scopesSplitted = strings.Split(strings.Replace(scopes, " ", "", -1), ",")
-
-		config = oauth2.Config{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
-			RedirectURL:  "",
-			Scopes:       scopesSplitted,
-			Endpoint: oauth2.Endpoint{
-				TokenURL: tokenURL,
-				AuthURL:  "",
-			},
-		}
-
+		scopeSplit = strings.Split(strings.Replace(scopes, " ", "", -1), ",")
 	} else {
-		config = oauth2.Config{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
-			RedirectURL:  "",
-			Endpoint: oauth2.Endpoint{
-				TokenURL: tokenURL,
-				AuthURL:  "",
-			},
-		}
+		scopeSplit = []string{}
+	}
+
+	config = oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  "",
+		Scopes:       scopeSplit,
+		Endpoint: oauth2.Endpoint{
+			TokenURL: tokenURL,
+			AuthURL:  "",
+		},
 	}
 
 	userCache = make(map[string]userState)


### PR DESCRIPTION
As scope are an optional feature, allow empty scope. If a user wants `all` scope, he should set `oauth_scopes` option accordingly.
I update the README with the option list.