### PR TITLE
Add option to define file path containing client secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ We use Keycloak and there you can customize your userinfo.
 
 Configuration options are listed below:
 
-| Options              | Description                                                                                         | Mandatory |
-|----------------------|-----------------------------------------------------------------------------------------------------|:---------:|
-| oauth_client_id      | Oauth2 Client id.                                                                                   |     Y     |
-| oauth_client_secret  | Oauth2 Client secret.                                                                               |     Y     |
-| oauth_token_url      | `token` endpoint url of the Oauth2 server.                                                          |     Y     |
-| oauth_userinfo_url   | `userinfo` endpoint url of the Oauth2 server.                                                       |     Y     |
-| oauth_cache_duration | Cache duration (in seconds) before the plugin request user info from Oauth2 server. `0` by default. |     N     |
-| oauth_scopes         | Comma separated list of requested scopes. No scope by default.                                      |     N     |
+| Options                    | Description                                                                                                                                                        | Mandatory |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------:|
+| `oauth_client_id`          | Oauth2 Client id.                                                                                                                                                  |     Y     |
+| `oauth_client_secret`      | Oauth2 Client secret. Either `oauth_client_secret` or `oauth_client_secret_file` must be set. If both are set, `oauth_client_secret_file` is used.                 |     N     |
+| `oauth_client_secret_file` | File containing Oauth2 Client secret. Either `oauth_client_secret` or `oauth_client_secret_file` must be set. If both are set, `oauth_client_secret_file` is used. |     N     |
+| `oauth_token_url`          | `token` endpoint url of the Oauth2 server.                                                                                                                         |     Y     |
+| `oauth_userinfo_url`       | `userinfo` endpoint url of the Oauth2 server.                                                                                                                      |     Y     |
+| `oauth_cache_duration`     | Cache duration (in seconds) before the plugin request user info from Oauth2 server. `0` by default.                                                                |     N     |
+| `oauth_scopes`             | Comma separated list of requested scopes. No scope by default.                                                                                                     |     N     |
 
 ## How to test
 

--- a/src/main.go
+++ b/src/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"mosquitto-go-auth-oauth2/topics"
 	"net/http"
 	"strconv"
@@ -186,9 +187,22 @@ func Init(authOpts map[string]string, logLevel log.Level) error {
 	if !ok {
 		log.Panic("Got no clientId for oauth plugin.")
 	}
-	clientSecret, ok := authOpts["oauth_client_secret"]
+	clientSecretFile, ok := authOpts["oauth_client_secret_file"]
 	if !ok {
-		log.Panic("Got no client secret for oauth plugin.")
+		log.Info("Got no client secret file for oauth plugin.")
+	}
+	var clientSecret string
+	if clientSecretFile == "" {
+		clientSecret, ok = authOpts["oauth_client_secret"]
+		if !ok {
+			log.Panic("Got no client secret for oauth plugin.")
+		}
+	} else {
+		content, err := ioutil.ReadFile(clientSecretFile)
+		if err != nil {
+			log.Panic("Client secret file for oauth plugin doesn't exist.")
+		}
+		clientSecret = string(content)
 	}
 	tokenURL, ok := authOpts["oauth_token_url"]
 	if !ok {


### PR DESCRIPTION
You can now define a file containing Oauth2 Client secret with `oauth_client_secret_file` option . Either `oauth_client_secret` or `oauth_client_secret_file` must be set. If both are set, `oauth_client_secret_file` is used. 

It's more convenient when you use a secret manager, and it decreases the risk of pushing the secret client by mistake by pushing go-auth.conf.